### PR TITLE
Add timing instrumentation

### DIFF
--- a/timer.py
+++ b/timer.py
@@ -1,0 +1,17 @@
+import time
+from typing import List
+
+class Timer:
+    """Simple context manager for timing code blocks."""
+    def __init__(self, storage: List[float]):
+        self.storage = storage
+        self._start = None
+
+    def __enter__(self):
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._start is not None:
+            self.storage.append(time.perf_counter() - self._start)
+        self._start = None


### PR DESCRIPTION
## Summary
- add a simple `Timer` context manager
- measure step times and total wall time in `run_experiment`
- save timing plot and CSV summary

## Testing
- `pytest -q`
- `python main.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686884eb11cc832e8271400733720a43